### PR TITLE
Improve console vim colorscheme

### DIFF
--- a/vim/gvimrc
+++ b/vim/gvimrc
@@ -1,3 +1,5 @@
+:colorscheme ir_black
+
 if filereadable(expand("~/.gvimrc.before"))
   source ~/.gvimrc.before
 endif

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -14,7 +14,7 @@ if has("autocmd")
   filetype plugin indent on
 endif
 
-:colorscheme ir_black
+:colorscheme koehler
 
 if has('mouse')
   set mouse=a


### PR DESCRIPTION
ir_black doesn't look well on console vim, koehler is a much better choice.
