### PR TITLE
fix ls color on darwin

### DIFF
--- a/bash/bash_profile.erb
+++ b/bash/bash_profile.erb
@@ -46,7 +46,12 @@ if [ -x /usr/bin/dircolors ]; then
     alias egrep='egrep --color=auto'
 fi
 
-alias ls='ls --color=auto'
+
+<% if @is_darwin %>
+  alias ls='ls -FGH'
+<% else %>
+  alias ls='ls --color=auto'
+<% end %>
 alias grep='grep --color=auto'
 
 alias ll='ls -alF'


### PR DESCRIPTION
When you install dofiles on Darwin system, throws errors when using **ls** command

``` bash
alias ls='ls --color=auto'
```

throws this error:

``` bash
ls
ls: illegal option -- -
usage: ls [-ABCFGHLOPRSTUWabcdefghiklmnopqrstuwx1] [file ...]
```

I've had this problem everytime I install the dotfiles in a system with Darwin, this is the solution to this bug:

``` bash
alias ls='ls -FGH'
```
