### PR TITLE
Fix control + L to work with tmux

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -24,3 +24,9 @@ setw -g automatic-rename
 # force a reload of the config file
 unbind r
 bind r source-file ~/.tmux.conf
+#
+# Fix control + l
+unbind-key C-l
+unbind ^L
+bind-key -n C-L send-keys -R
+bind-key -n C-l send-keys -R


### PR DESCRIPTION
This works much better for example running a tail and cleaning the output. 

otherwise you need to do <c-bindkey> :send-keys -R
