### PR TITLE
Add vim-eco and remove git-submodules from installer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -31,8 +31,6 @@ end
 
 desc "Install vim config"
 task :vim do
-  system 'git submodule update --init'
-
   %w/vimrc gvimrc/.each do |file|
     copy_to_build 'vim', file
   end

--- a/vim/README.md
+++ b/vim/README.md
@@ -93,6 +93,10 @@ Supertab allows you to use <Tab> for all your insert completion needs
 ### NerdCommenter
 A plugin that allows for easy commenting of code for many filetypes.
 
+### Vim-eco
+
+Add support for eco files syntax highlight
+
 ## Tweaks
 * Leader is mapped to space
 * Removed bom

--- a/vim/vimrc
+++ b/vim/vimrc
@@ -35,6 +35,7 @@ Plugin 'jinfield/vim-nginx'
 Plugin 'sjbach/lusty'
 Plugin 'ervandew/supertab.git'
 Plugin 'scrooloose/nerdcommenter'
+Plugin 'AndrewRadev/vim-eco'
 
 " Themes
 Plugin 'altercation/vim-colors-solarized'
@@ -189,5 +190,4 @@ endif
 
 let g:closetag_html_style=1
 autocmd FileType html,xhtml,xml,htmldjango,jinjahtml,eruby,mako,eco silent!
-autocmd BufRead,BufNewFile *.eco set filetype=html
 " vim: filetype=vim


### PR DESCRIPTION
Add vim-eco to provide full support for eco templating as oppose to treating them as HTML since the html plugin will mark eco specific syntax as HTML errors.
