### PR TITLE
Remove --experimental-features (removed from picom) and remove deprecated window type specifiers

### DIFF
--- a/.config/picom/picom.conf
+++ b/.config/picom/picom.conf
@@ -86,8 +86,6 @@ shadow-exclude = [
     "class_g ?= 'Cairo-dock'",
     "class_g ?= 'Xfce4-notifyd'",
     "class_g ?= 'Xfce4-power-manager'",
-    "_GTK_FRAME_EXTENTS@:c",
-    "_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'"
 ];
 # Avoid drawing shadow on all shaped windows (see also: --detect-rounded-corners)
 shadow-ignore-shaped = false;

--- a/.xprofile
+++ b/.xprofile
@@ -3,7 +3,7 @@
 xrandr --output eDP-1-1 --primary --mode 3840x2160 --dpi 200.26 --brightness 0.75
 
 # Start compositor
-picom --experimental-backends --blur-method dual_kawase --blur-strength 7 -b &
+picom --blur-method dual_kawase --blur-strength 7 -b &
 
 # Set keyboard layout
 setxkbmap -layout us,us -variant ,intl -option grp:alt_shift_toggle


### PR DESCRIPTION
This pull request includes changes to the configuration files for the compositor and display settings. The most important changes involve modifications to the `picom` configuration and the `.xprofile` script.

Changes to `picom` configuration:

* Removed specific rules for excluding shadows on windows with `_GTK_FRAME_EXTENTS` and `_NET_WM_STATE_HIDDEN` properties in `.config/picom/picom.conf`.

Changes to `.xprofile` script:

* Removed the `--experimental-backends` flag from the `picom` startup command in `.xprofile`.